### PR TITLE
Add Local Authority Labels

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,6 +46,29 @@ function setup_amChartmap(){
 }
 
 
+/**
+ * Find a short tooltip label for local authority classes in germany.
+ * Keep a reasonable default for unknown new classes.
+ */
+function localAuthorityToolTip(pointProperties) {
+    var bez = pointProperties.BEZ;
+    var prefix = bez + ' ';
+    if (bez == 'Landkreis') {
+        prefix = 'LK ';
+    }
+    if (bez == 'Kreis') {
+        prefix = 'Kr ';
+    }
+    if (bez == 'Stadtkreis') {
+        prefix = 'SK ';
+    }
+    if (bez == 'Kreisfreie Stadt') {
+        prefix = 'Stadt ';
+    }
+    return prefix + pointProperties.GEN;
+}
+
+
 window.addEventListener("load", setup_highchartsmap);
 
 var geo_json;
@@ -177,7 +200,7 @@ function setup_highchartsmap(){
     tooltip: {
     	useHTML: true,
     	formatter: function(tooltip){
-    		name = this.point.properties.GEN;
+    		name = localAuthorityToolTip(this.point.properties);
     		wc = this.point["weekly_cases"];
     		i = this.point["inzidenz"];
     		

--- a/index.html
+++ b/index.html
@@ -28,10 +28,10 @@
     <h5>Altersgruppen</h5>
     <label class="radio-inline"><input id="All age groups" type="radio" name="optradio" checked>Alle</label>
     <label class="radio-inline"><input id="A00-A04" type="radio" name="optradio">A00-A04</label>
-    <label class="radio-inline"><input id="A05-A14"type="radio" name="optradio">A05-A14</label>
-    <label class="radio-inline"><input id="A15-A34"type="radio" name="optradio">A15-A34</label> 
-    <label class="radio-inline"><input id="A35-A59"type="radio" name="optradio">A35-A59</label> 
-    <label class="radio-inline"><input id="A60-A79"type="radio" name="optradio">A60-A79</label> 
+    <label class="radio-inline"><input id="A05-A14" type="radio" name="optradio">A05-A14</label>
+    <label class="radio-inline"><input id="A15-A34" type="radio" name="optradio">A15-A34</label>
+    <label class="radio-inline"><input id="A35-A59" type="radio" name="optradio">A35-A59</label>
+    <label class="radio-inline"><input id="A60-A79" type="radio" name="optradio">A60-A79</label>
     <label class="radio-inline"><input id="A80+" type="radio" name="optradio">A80+</label>
     Updated <label id="lastcommitdate"></label> with RKI data.
   </div>


### PR DESCRIPTION
Since authority names in germany are not unique as pointed out in #4, I added a prefix for the tooltip indicating the four authority classes used in the data set, which only use a subset of the real official classes in the different federal states and free cities.