### PR TITLE
Fix HDF5 cdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
 
     <!-- HDF5 js-->
-    <script src="https://cdn.jsdelivr.net/gh/usnistgov/jsfive@master/dist/hdf5.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsfive@0.3.7/dist/hdf5.js"></script>
 
     <!-- Own utils-->
     <script src="assets/js/utils.js"></script>


### PR DESCRIPTION
HDF5 CDN resource seems broken, replaced with URL from https://github.com/usnistgov/jsfive docs.